### PR TITLE
Added verification of the Signatures of Amazon SNS Messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.4|~6.0"
+        "illuminate/support": "~5.4|~6.0",
+        "aws/aws-php-sns-message-validator": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Events/SnsEvent.php
+++ b/src/Events/SnsEvent.php
@@ -2,6 +2,7 @@
 
 namespace Rennokki\LaravelSnsEvents\Events;
 
+use Aws\Sns\Message;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
@@ -15,10 +16,10 @@ class SnsEvent
     /**
      * Create a new event instance.
      *
-     * @return void
+     * @param Message $message
      */
-    public function __construct($message)
+    public function __construct(Message $message)
     {
-        $this->message = $message;
+        $this->message = $message->toArray();
     }
 }

--- a/src/Http/Controllers/SnsController.php
+++ b/src/Http/Controllers/SnsController.php
@@ -2,6 +2,9 @@
 
 namespace Rennokki\LaravelSnsEvents\Http\Controllers;
 
+use Aws\Sns\Exception\InvalidSnsMessageException;
+use Aws\Sns\Message;
+use Aws\Sns\MessageValidator;
 use Illuminate\Routing\Controller;
 use Rennokki\LaravelSnsEvents\Events\SnsEvent;
 use Rennokki\LaravelSnsEvents\Events\SnsSubscriptionConfirmation;
@@ -10,17 +13,29 @@ class SnsController extends Controller
 {
     public function handle()
     {
-        $message = json_decode(file_get_contents('php://input'), true);
+        // Instantiate the Message and Validator
+        $message = Message::fromRawPostData();
+        $validator = new MessageValidator();
 
-        if (isset($message['Type']) && $message['Type'] === 'SubscriptionConfirmation') {
+        // Validate the message.
+        try {
+            $validator->validate($message);
+        } catch (InvalidSnsMessageException $e) {
+            // Return 404 to pretend we are not here for SNS if invalid request
+            return response('SNS Message Validation Error: ' . $e->getMessage(), 404);
+        }
+
+        // Check the type of the message and handle the subscription.
+        if ($message['Type'] === 'SubscriptionConfirmation') {
+            // Confirm the subscription by sending a GET request to the SubscribeURL
             file_get_contents($message['SubscribeURL']);
-
             event(new SnsSubscriptionConfirmation);
-
             return response('OK', 200);
         }
 
-        event(new SnsEvent($message));
+        if ($message['Type'] === 'Notification') {
+            event(new SnsEvent($message));
+        }
 
         return response('OK', 200);
     }

--- a/src/Http/Controllers/SnsController.php
+++ b/src/Http/Controllers/SnsController.php
@@ -30,6 +30,7 @@ class SnsController extends Controller
             // Confirm the subscription by sending a GET request to the SubscribeURL
             file_get_contents($message['SubscribeURL']);
             event(new SnsSubscriptionConfirmation);
+
             return response('OK', 200);
         }
 

--- a/src/Http/Controllers/SnsController.php
+++ b/src/Http/Controllers/SnsController.php
@@ -2,11 +2,11 @@
 
 namespace Rennokki\LaravelSnsEvents\Http\Controllers;
 
-use Aws\Sns\Exception\InvalidSnsMessageException;
 use Aws\Sns\Message;
 use Aws\Sns\MessageValidator;
 use Illuminate\Routing\Controller;
 use Rennokki\LaravelSnsEvents\Events\SnsEvent;
+use Aws\Sns\Exception\InvalidSnsMessageException;
 use Rennokki\LaravelSnsEvents\Events\SnsSubscriptionConfirmation;
 
 class SnsController extends Controller
@@ -22,7 +22,7 @@ class SnsController extends Controller
             $validator->validate($message);
         } catch (InvalidSnsMessageException $e) {
             // Return 404 to pretend we are not here for SNS if invalid request
-            return response('SNS Message Validation Error: ' . $e->getMessage(), 404);
+            return response('SNS Message Validation Error: '.$e->getMessage(), 404);
         }
 
         // Check the type of the message and handle the subscription.


### PR DESCRIPTION
Adds Amazon SNS Validation to incoming requests to make sure the requests are valid and has not been tampered. If a request is not valid, no event will fire. Returns 404 to any subscription request that is invalid; this is done to "hide" for invalid requests.

@rennokki 