### PR TITLE
[feature] Separate payload for subscription confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,15 @@ By default, the payload looks like this:
 ```php
 use Illuminate\Http\Request;
 
-protected function getEventPayload(array $snsMessage, Request $request): array
+/**
+ * Get the event payload to stream to the event in case
+ * AWS sent a notification payload.
+ *
+ * @param  array  $snsMessage
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
+protected function getNotificationPayload(array $snsMessage, Request $request): array
 {
     // $snsMessage is the SNS message from the request body (as array)
     // You may also access the request.
@@ -108,19 +116,45 @@ protected function getEventPayload(array $snsMessage, Request $request): array
 }
 ```
 
-While extending the controller, you can replace the `getEventPayload` method with your own:
+While extending the controller, you can replace the `getNotificationPayload` and `getSubscriptionConfirmationPayload` methods with your own:
 
 ```php
 use Illuminate\Http\Request;
 
-protected function getEventPayload(array $snsMessage, Request $request): array
+/**
+ * Get the event payload to stream to the event in case
+ * AWS sent a notification payload.
+ *
+ * @param  array  $snsMessage
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
+protected function getNotificationPayload(array $snsMessage, Request $request): array
 {
     return [
         'message' => $snsMessage,
         'user' => $request->user(),
     ];
 }
+
+/**
+ * Get the event payload to stream to the event in case
+ * AWS sent a subscription confirmation payload.
+ *
+ * @param  array  $snsMessage
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
+protected function getSubscriptionConfirmationPayload(array $snsMessage, Request $request): array
+{
+    return [
+        'message' => $snsMessage,
+        'headers' => $request->headers->all(),
+    ];
+}
 ```
+
+This way, you can customize the payloads for both Subscription Confirmation `SnsSubscriptionConfirmation` and the usual Notification `SnsEvent`.
 
 **Remember that after extending the controller, to point the SNS route defined earlier to the new controller.**
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ composer require rennokki/laravel-sns-events
 
 There are two classes that get triggered, depending on the request sent by AWS:
 
-* `Rennokki\LaravelSnsEvents\Events\SnsEvent` - triggered on each SNS notification
+* `Rennokki\LaravelSnsEvents\Events\SnsNotification` - triggered on each SNS notification
 * `Rennokki\LaravelSnsEvents\Events\SnsSubscriptionConfirmation` - triggered when the subscription is confirmed
 
 A controller that will handle the response for you should be registered in your routes:
@@ -53,14 +53,14 @@ If you have registered the route and created a SNS Topic, you should register th
 To process the events, you should add the events in your `app/Providers/EventServiceProvider.php`:
 
 ```php
-use Rennokki\LaravelSnsEvents\Events\SnsEvent;
+use Rennokki\LaravelSnsEvents\Events\SnsNotification;
 use Rennokki\LaravelSnsEvents\Events\SnsSubscriptionConfirmation;
 
 ...
 
 protected $listen = [
     ...
-    SnsEvent::class => [
+    SnsNotification::class => [
         // add your listeners here for SNS events
     ],
     SnsSubscriptionConfirmation::class => [
@@ -154,7 +154,7 @@ protected function getSubscriptionConfirmationPayload(array $snsMessage, Request
 }
 ```
 
-This way, you can customize the payloads for both Subscription Confirmation `SnsSubscriptionConfirmation` and the usual Notification `SnsEvent`.
+This way, you can customize the payloads for both Subscription Confirmation `SnsSubscriptionConfirmation` and the usual Notification `SnsNotification`.
 
 **Remember that after extending the controller, to point the SNS route defined earlier to the new controller.**
 
@@ -193,9 +193,9 @@ To avoid any issues, remember to extend the respective, original event classes b
 ```php
 // CustomSnsEvent.php
 
-use Rennokki\LaravelSnsEvents\Events\SnsEvent;
+use Rennokki\LaravelSnsEvents\Events\SnsNotification;
 
-class CustomSnsEvent extends SnsEvent
+class CustomSnsEvent extends SnsNotification
 {
     //
 }

--- a/src/Events/SnsNotification.php
+++ b/src/Events/SnsNotification.php
@@ -2,7 +2,7 @@
 
 namespace Rennokki\LaravelSnsEvents\Events;
 
-class SnsEvent
+class SnsNotification
 {
     /**
      * The payload to be delivered in the listeners.

--- a/src/Events/SnsSubscriptionConfirmation.php
+++ b/src/Events/SnsSubscriptionConfirmation.php
@@ -2,7 +2,7 @@
 
 namespace Rennokki\LaravelSnsEvents\Events;
 
-class SnsSubscriptionConfirmation extends SnsEvent
+class SnsSubscriptionConfirmation extends SnsNotification
 {
     //
 }

--- a/src/Http/Controllers/SnsController.php
+++ b/src/Http/Controllers/SnsController.php
@@ -4,7 +4,7 @@ namespace Rennokki\LaravelSnsEvents\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Rennokki\LaravelSnsEvents\Events\SnsEvent;
+use Rennokki\LaravelSnsEvents\Events\SnsNotification;
 use Rennokki\LaravelSnsEvents\Events\SnsSubscriptionConfirmation;
 
 class SnsController extends Controller
@@ -110,6 +110,6 @@ class SnsController extends Controller
      */
     protected function getNotificationEventClass(): string
     {
-        return SnsEvent::class;
+        return SnsNotification::class;
     }
 }

--- a/tests/Controllers/CustomSnsController.php
+++ b/tests/Controllers/CustomSnsController.php
@@ -10,17 +10,34 @@ use Rennokki\LaravelSnsEvents\Tests\Events\CustomSubscriptionConfirmation;
 class CustomSnsController extends SnsController
 {
     /**
-     * Get the event payload to stream to the event.
+     * Get the event payload to stream to the event in case
+     * AWS sent a notification payload.
      *
      * @param  array  $snsMessage
      * @param  \Illuminate\Http\Request  $request
      * @return array
      */
-    protected function getEventPayload(array $snsMessage, Request $request): array
+    protected function getNotificationPayload(array $snsMessage, Request $request): array
     {
         return [
             'message' => $snsMessage,
             'test' => $request->query('test'),
+        ];
+    }
+
+    /**
+     * Get the event payload to stream to the event in case
+     * AWS sent a subscription confirmation payload.
+     *
+     * @param  array  $snsMessage
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    protected function getSubscriptionConfirmationPayload(array $snsMessage, Request $request): array
+    {
+        return [
+            'message' => $snsMessage,
+            'confirmation_test' => $request->query('test'),
         ];
     }
 

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -93,7 +93,7 @@ class EventTest extends TestCase
 
         Event::assertDispatched(CustomSubscriptionConfirmation::class, function ($event) {
             $this->assertEquals(
-                'some-string', $event->payload['test']
+                'some-string', $event->payload['confirmation_test']
             );
 
             $this->assertFalse(

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -3,7 +3,7 @@
 namespace Rennokki\LaravelSnsEvents\Tests;
 
 use Illuminate\Support\Facades\Event;
-use Rennokki\LaravelSnsEvents\Events\SnsEvent;
+use Rennokki\LaravelSnsEvents\Events\SnsNotification;
 use Rennokki\LaravelSnsEvents\Events\SnsSubscriptionConfirmation;
 use Rennokki\LaravelSnsEvents\Tests\Events\CustomSnsEvent;
 use Rennokki\LaravelSnsEvents\Tests\Events\CustomSubscriptionConfirmation;
@@ -18,7 +18,7 @@ class EventTest extends TestCase
             ->json('GET', route('sns'))
             ->assertSee('OK');
 
-        Event::assertNotDispatched(SnsEvent::class);
+        Event::assertNotDispatched(SnsNotification::class);
         Event::assertNotDispatched(SnsSubscriptionConfirmation::class);
     }
 
@@ -33,7 +33,7 @@ class EventTest extends TestCase
             ->json('POST', route('sns'), $this->getSubscriptionConfirmationPayload())
             ->assertSee('OK');
 
-        Event::assertNotDispatched(SnsEvent::class);
+        Event::assertNotDispatched(SnsNotification::class);
 
         Event::assertDispatched(SnsSubscriptionConfirmation::class, function ($event) {
             $this->assertTrue(
@@ -62,7 +62,7 @@ class EventTest extends TestCase
 
         Event::assertNotDispatched(SnsSubscriptionConfirmation::class);
 
-        Event::assertDispatched(SnsEvent::class, function ($event) {
+        Event::assertDispatched(SnsNotification::class, function ($event) {
             $this->assertTrue(
                 isset($event->payload['headers']['x-test-header'])
             );

--- a/tests/Events/CustomSnsEvent.php
+++ b/tests/Events/CustomSnsEvent.php
@@ -2,9 +2,9 @@
 
 namespace Rennokki\LaravelSnsEvents\Tests\Events;
 
-use Rennokki\LaravelSnsEvents\Events\SnsEvent;
+use Rennokki\LaravelSnsEvents\Events\SnsNotification;
 
-class CustomSnsEvent extends SnsEvent
+class CustomSnsEvent extends SnsNotification
 {
     //
 }


### PR DESCRIPTION
This PR adds some naming breaking changes:

- the `getEventPayload` method got replaced with `getNotificationPayload`
- the `getSubscriptionConfirmationPayload` method got added

This way, you can customize the payloads for notifications (ex. Cloudwatch alarms) and for subscription confirmation, when registering the endpoint in SNS.

- the `\Rennokki\LaravelSnsEvents\Events\SnsEvent` event class got changed to `Rennokki\LaravelSnsEvents\Events\SnsNotification`

It's just a naming convention because the real name of the message sent by AWS is `Notification`, so it should be clearer.