### PR TITLE
[Refactor] Resolve MessageValidator from Container

### DIFF
--- a/src/Concerns/HandlesSns.php
+++ b/src/Concerns/HandlesSns.php
@@ -51,6 +51,6 @@ trait HandlesSns
      */
     protected function getMessageValidator(Request $request)
     {
-        return new MessageValidator;
+        return resolve(MessageValidator::class);
     }
 }


### PR DESCRIPTION
I Changed the `getMessageValidator()` so you can swap validation implementations without extending the controller.

This allows you to mock the MessageValidator so you don't have to rely on amazon's services to write some tests.

That lets users add something like this 

    \Facades\Aws\Sns\MessageValidator::shouldReceive('isValid')->andReturn(true);

for testing instead of messing around with the ssl certs and such.