### PR TITLE
Cleanup composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,10 @@
         }
     ],
     "require": {
-        "laravel/framework": "^6.0|^7.0|^8.0",
+        "php": "^7.1",
+        "illuminate/http": "^6.0|^7.0|^8.0",
+        "illuminate/routing": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0",
         "aws/aws-php-sns-message-validator": "^1.6"
     },
     "autoload": {
@@ -44,5 +47,6 @@
     "config": {
         "sort-packages": true
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
- Require php >= 7.1
  *Above change is based on (static) code analysis using PhpStorm*

- Use Illuminate packages instead of laravel/framework
  *This allows the package to be used outside of a full laravel install*

- Add "prefer-stable"
  *This ensures that by default only stable packages are installed during development (unless explicitly requested otherwise) to reduce the chance that unreleased features are used*