### PR TITLE
[7.x] Simplifying the testing trait

### DIFF
--- a/src/Concerns/GeneratesSnsMessages.php
+++ b/src/Concerns/GeneratesSnsMessages.php
@@ -8,21 +8,21 @@ use Aws\Sns\MessageValidator;
 trait GeneratesSnsMessages
 {
     /**
-     * Get the private key to sign the request.
+     * Get the private key to sign the request for SNS.
      *
      * @var string
      */
-    protected static $privateKey;
+    protected static $snsPrivateKey;
 
     /**
-     * The certificate to sign the request.
+     * The certificate to sign the request for SNS.
      *
      * @var string
      */
-    protected static $certificate;
+    protected static $snsCertificate;
 
     /**
-     * An valid certificate URL for test.
+     * An valid certificate URL to test SNS.
      *
      * @var string
      */
@@ -35,13 +35,13 @@ trait GeneratesSnsMessages
      */
     protected static function initializeSsl(): void
     {
-        self::$privateKey = openssl_pkey_new();
+        self::$snsPrivateKey = openssl_pkey_new();
 
-        $csr = openssl_csr_new([], self::$privateKey);
+        $csr = openssl_csr_new([], self::$snsPrivateKey);
 
-        $x509 = openssl_csr_sign($csr, null, self::$privateKey, 1);
+        $x509 = openssl_csr_sign($csr, null, self::$snsPrivateKey, 1);
 
-        openssl_x509_export($x509, self::$certificate);
+        openssl_x509_export($x509, self::$snsCertificate);
     }
 
     /**
@@ -52,7 +52,7 @@ trait GeneratesSnsMessages
      */
     protected function getSignature($stringToSign)
     {
-        openssl_sign($stringToSign, $signature, self::$privateKey);
+        openssl_sign($stringToSign, $signature, self::$snsPrivateKey);
 
         return base64_encode($signature);
     }

--- a/src/Concerns/GeneratesSnsMessages.php
+++ b/src/Concerns/GeneratesSnsMessages.php
@@ -42,20 +42,6 @@ trait GeneratesSnsMessages
         $x509 = openssl_csr_sign($csr, null, self::$privateKey, 1);
 
         openssl_x509_export($x509, self::$certificate);
-
-        // Deprecated in PHP >= 8.0
-        // openssl_x509_free($x509);
-    }
-
-    /**
-     * Deinitialize the SSL keys.
-     *
-     * @return void
-     */
-    protected static function tearDownSsl(): void
-    {
-        // Deprecated in PHP >= 8.0
-        // openssl_pkey_free(self::$privateKey);
     }
 
     /**

--- a/src/Concerns/HandlesSns.php
+++ b/src/Concerns/HandlesSns.php
@@ -6,6 +6,7 @@ use Aws\Sns\Message;
 use Aws\Sns\MessageValidator;
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
 
 trait HandlesSns
 {
@@ -51,6 +52,8 @@ trait HandlesSns
      */
     protected function getMessageValidator(Request $request)
     {
-        return new MessageValidator;
+        return App::environment(['testing', 'local'])
+            ? new MessageValidator(fn ($url) => $request->certificate ?: $url)
+            : new MessageValidator;
     }
 }

--- a/src/Concerns/HandlesSns.php
+++ b/src/Concerns/HandlesSns.php
@@ -52,8 +52,20 @@ trait HandlesSns
      */
     protected function getMessageValidator(Request $request)
     {
-        return App::environment(['testing', 'local'])
-            ? new MessageValidator(fn ($url) => $request->certificate ?: $url)
-            : new MessageValidator;
+        if (App::environment(['testing', 'local'])) {
+            return new MessageValidator(function ($url) use ($request) {
+                if ($certificate = $request->sns_certificate) {
+                    return $certificate;
+                }
+
+                if ($certificate = $request->header('X-Sns-Testing-Certificate')) {
+                    return $certificate;
+                }
+
+                return $url;
+            });
+        }
+
+        return new MessageValidator;
     }
 }

--- a/tests/Controllers/CustomSnsController.php
+++ b/tests/Controllers/CustomSnsController.php
@@ -2,7 +2,6 @@
 
 namespace Rennokki\LaravelSnsEvents\Tests\Controllers;
 
-use Aws\Sns\MessageValidator;
 use Illuminate\Http\Request;
 use Rennokki\LaravelSnsEvents\Http\Controllers\SnsController;
 use Rennokki\LaravelSnsEvents\Tests\Events\CustomSnsEvent;
@@ -86,18 +85,5 @@ class CustomSnsController extends SnsController
     protected function onSubscriptionConfirmation(array $snsMessage, Request $request): void
     {
         mt_rand(0, 10000);
-    }
-
-    /**
-     * Get the message validator instance.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Aws\Sns\MessageValidator
-     */
-    protected function getMessageValidator(Request $request)
-    {
-        return new MessageValidator(function ($url) use ($request) {
-            return $request->certificate ?: $url;
-        });
     }
 }

--- a/tests/Controllers/SnsController.php
+++ b/tests/Controllers/SnsController.php
@@ -2,22 +2,9 @@
 
 namespace Rennokki\LaravelSnsEvents\Tests\Controllers;
 
-use Aws\Sns\MessageValidator;
-use Illuminate\Http\Request;
 use Rennokki\LaravelSnsEvents\Http\Controllers\SnsController as BaseSnsController;
 
 class SnsController extends BaseSnsController
 {
-    /**
-     * Get the message validator instance.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Aws\Sns\MessageValidator
-     */
-    protected function getMessageValidator(Request $request)
-    {
-        return new MessageValidator(function ($url) use ($request) {
-            return $request->certificate ?: $url;
-        });
-    }
+    //
 }

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -14,23 +14,19 @@ class EventTest extends TestCase
     {
         Event::fake();
 
-        $this->json('GET', route('sns'))
-            ->assertSee('OK');
+        $this->sendSnsMessage(route('sns'))->assertSee('OK');
 
         Event::assertNotDispatched(SnsNotification::class);
         Event::assertNotDispatched(SnsSubscriptionConfirmation::class);
 
-        $this->json('GET', route('sns', ['certificate' => static::$certificate]))
-            ->assertSee('OK');
+        $this->sendSnsMessage(route('sns'))->assertSee('OK');
 
         Event::assertNotDispatched(SnsNotification::class);
         Event::assertNotDispatched(SnsSubscriptionConfirmation::class);
 
         $payload = $this->getSubscriptionConfirmationPayload();
 
-        $this->withHeaders($this->getHeadersForMessage($payload))
-            ->json('GET', route('sns', ['certificate' => static::$certificate]))
-            ->assertSee('OK');
+        $this->sendSnsMessage(route('sns'))->assertSee('OK');
 
         Event::assertNotDispatched(SnsNotification::class);
         Event::assertNotDispatched(SnsSubscriptionConfirmation::class);
@@ -42,11 +38,9 @@ class EventTest extends TestCase
 
         $payload = $this->getSubscriptionConfirmationPayload();
 
-        $this->withHeaders(array_merge($this->getHeadersForMessage($payload), [
-            'x-test-header' => 1,
-        ]))
-        ->json('POST', route('sns', ['certificate' => static::$certificate]), $payload)
-        ->assertSee('OK');
+        $this->withHeaders(['x-test-header' => 1])
+            ->sendSnsMessage(route('sns'), $payload)
+            ->assertSee('OK');
 
         Event::assertNotDispatched(SnsNotification::class);
 
@@ -68,11 +62,9 @@ class EventTest extends TestCase
             'sns' => true,
         ]);
 
-        $this->withHeaders(array_merge($this->getHeadersForMessage($payload), [
-            'x-test-header' => 1,
-        ]))
-        ->json('POST', route('sns', ['certificate' => static::$certificate]), $payload)
-        ->assertSee('OK');
+        $this->withHeaders(['x-test-header' => 1])
+            ->sendSnsMessage(route('sns'), $payload)
+            ->assertSee('OK');
 
         Event::assertNotDispatched(SnsSubscriptionConfirmation::class);
 
@@ -98,11 +90,9 @@ class EventTest extends TestCase
 
         $payload = $this->getSubscriptionConfirmationPayload();
 
-        $this->withHeaders(array_merge($this->getHeadersForMessage($payload), [
-            'x-test-header' => 1,
-        ]))
-        ->json('POST', route('custom-sns', ['test' => 'some-string', 'certificate' => static::$certificate]), $payload)
-        ->assertSee('OK');
+        $this->withHeaders(['x-test-header' => 1])
+            ->sendSnsMessage(route('custom-sns', ['test' => 'some-string']), $payload)
+            ->assertSee('OK');
 
         Event::assertNotDispatched(CustomSnsEvent::class);
 
@@ -128,11 +118,9 @@ class EventTest extends TestCase
             'sns' => true,
         ]);
 
-        $this->withHeaders(array_merge($this->getHeadersForMessage($payload), [
-            'x-test-header' => 1,
-        ]))
-        ->json('POST', route('custom-sns', ['test' => 'some-string', 'certificate' => static::$certificate]), $payload)
-        ->assertSee('OK');
+        $this->withHeaders(['x-test-header' => 1])
+            ->sendSnsMessage(route('custom-sns', ['test' => 'some-string']), $payload)
+            ->assertSee('OK');
 
         Event::assertNotDispatched(CustomSubscriptionConfirmation::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,14 +10,6 @@ class TestCase extends Orchestra
     use GeneratesSnsMessages;
 
     /**
-     * {@inheritdoc}
-     */
-    public static function setUpBeforeClass(): void
-    {
-        static::initializeSsl();
-    }
-
-    /**
      * Get package providers.
      *
      * @param  \Illuminate\Foundation\Application  $app

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,6 @@ class TestCase extends Orchestra
      * Get package providers.
      *
      * @param  \Illuminate\Foundation\Application  $app
-     *
      * @return array
      */
     protected function getPackageProviders($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,14 +18,6 @@ class TestCase extends Orchestra
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public static function tearDownAfterClass(): void
-    {
-        static::tearDownSsl();
-    }
-
-    /**
      * Get package providers.
      *
      * @param  \Illuminate\Foundation\Application  $app


### PR DESCRIPTION
## Updated `Rennokki\LaravelSnsEvents\Concerns\GeneratesSnsMessages` trait

Instead of manually using `->json('POST', $yourWebhookUrl)`, you can now import the trait in your `TestCase` class and use the `sendSnsMessage` method.

The certificate used for testing is auto-generated with OpenSSL and is auto-injected. 

```php
$payload = $this->getNotificationPayload(['test' => 1, 'sns' => true]);

$this->sendSnsMessage('/webhook', $payload)->assertOk();
```

- SSL certificate for testing now auto-initializes (you should remove the custom `initializeSsl()` method defined in your `TestCase`, if you have any
- Renamed `$privateKey` to `$snsPrivateKey` to avoid conflicts
- Renamed `$certificate` to `$snsCertificate` to avoid conflicts
- Renamed `$validCertUrl` to `$snsValidCertUrl` to avoid conflicts
- For manual testing, either in `local` or `testing`, you can pass `sns_certificate` as query string or `X-Sns-Testing-Certificate` as header to inject your certificate for message signing testing