### PR TITLE
Extract subscribe url call to method

### DIFF
--- a/src/Http/Controllers/SnsController.php
+++ b/src/Http/Controllers/SnsController.php
@@ -28,7 +28,9 @@ class SnsController extends Controller
 
         if (isset($snsMessage['Type'])) {
             if ($snsMessage['Type'] === 'SubscriptionConfirmation') {
-                @file_get_contents($snsMessage['SubscribeURL']);
+                if (! $this->callSubscribeUrl($snsMessage['SubscribeURL'])) {
+                    return $this->okStatus();
+                }
 
                 $class = $this->getSubscriptionConfirmationEventClass();
 
@@ -134,5 +136,16 @@ class SnsController extends Controller
     protected function okStatus()
     {
         return response('OK', 200);
+    }
+
+    /**
+     * Make a call to the subscribe URL to confirm the subscription.
+     *
+     * @param  string  $url
+     * @return bool
+     */
+    protected function callSubscribeUrl(string $url): bool
+    {
+        return @file_get_contents($url) !== false;
     }
 }


### PR DESCRIPTION
This PR extracts the (currently hardcoded) `file_get_contents` call for confirming the subscription to a method, so that it can be overwritten by consumers. The reason for this is that I have disabled `allow_url_fopen` on my production environment, so using `file_get_contents` with a URL fails. This PR allows me to switch this to using another solution, like Laravel's HTTP client.

Another small change here is that I added a check to see if the subscription confirmation call succeeded, and otherwise don't fire the respective events. Let me know if you'd like to keep this change, otherwise I'll roll back to just the method extraction :) 